### PR TITLE
Add reconnect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,36 @@ Create a client, then call bloomd commands directly on it. A simple example:
       client = bloomd.createClient()
 
   client.on('error', function (err) {
-      console.log('Error:' + err)
+    console.log('Error:' + err)
   })
 
+  function printer(error, data) {
+    console.log(data)
+  }
+
   client.list(null, bloomd.print)
-  client.create('newFilter', bloomd.print)
+  client.create('newFilter', printer)
   client.info('newFilter', bloomd.print)
-  client.check('newFilter', 'monkey', bloomd.print)
-  client.set('newFilter', 'monkey', bloomd.print)
-  client.check('newFilter', 'monkey', bloomd.print)
-  client.bulk('newFilter', ['monkey', 'magic', 'muppet'], bloomd.print)
-  client.multi('newFilter', ['monkey', 'magic', 'muppet'], bloomd.print)
+  client.check('newFilter', 'monkey', printer) 
+  client.set('newFilter', 'monkey', printer)
+  client.check('newFilter', 'monkey', printer) 
+  client.bulk('newFilter', ['monkey', 'magic', 'muppet'], printer) 
+  client.multi('newFilter', ['monkey', 'magic', 'muppet'], printer) 
   client.info('newFilter', bloomd.print)
-  client.drop('newFilter', bloomd.print)
-  client.dispose()
+  client.drop('newFilter', printer) 
+  client.dispose() 
 ```
+
+Client Options
+--------------
+
+A number of config options are available for the client:
+
+* ```host [127.0.0.1]```: The host of bloomd to connect to.
+* ```port [8673]```: The port to connect on.
+* ```debug [false]```: Outputs debug information to the log.
+* ```reconnectDelay [160]```: The base amount of time in ms to wait between reconnection attempts. This number is multiplied by the current count of reconnection attempts to give a measure of backoff.
+* ```maxConnectionAttempts [0]```: The amount of times to try to get a connection to bloomd, after which the client will declare itself unavailable. 0 means no limit.
 
 Memorable Commands
 ------------------
@@ -114,9 +129,7 @@ Finally, 'safe' is a terrible designation, and I welcome suggestions for a bette
 Still To Do
 -----------
 
-* Retry and reconnect support.
 * More Error checking.
-* Additional tests.
 * Instrumentation and optimisation.
 * Better documentation.
 * Auto-retry of filter creation when failing due to the filter having recently been dropped.
@@ -138,7 +151,7 @@ Author
 License
 -------
 
-Copyright 2013 [Medium](https://medium.com)
+Copyright 2013 [The Obvious Corporation](https://medium.com)
 
 Licensed under Apache License Version 2.0.  Details in the attached LICENSE
 file.

--- a/lib/responseParser.js
+++ b/lib/responseParser.js
@@ -1,5 +1,7 @@
+// Copyright 2013 The Obvious Corporation
+
 var stream = require('stream'),
-  util = require('util')
+    util = require('util')
 
 /**
  * A named bloom filter object.
@@ -80,7 +82,7 @@ ResponseParser.prototype._transform = function (chunk, encoding, done) {
         if ('END' === this.lines[i]) {
           // Got a full list. Push it and continue parsing.
           this.push(this.lines.splice(0, i + 1).slice(1, -1))
-          
+
           // Reset the block count for the next block.
           this.blockLines = 1
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bloomd"
   , "description": "NodeJS Driver for BloomD"
-  , "version": "0.2.0"
+  , "version": "0.2.1"
   , "homepage": "https://github.com/obvious/node-bloomd"
   , "authors": [
     "Jamie Talbot <jamie@jamietalbot.com> (https://github.com/majelbstoat)"
@@ -18,7 +18,8 @@
   , "dependencies": {
   }
   , "devDependencies": {
-        "nodeunit": "0.7.4"
+        "nodeunit": "0.7.4",
+        "sleep": "1.1.1"
     }
   , "scripts": {
       "test": "./node_modules/nodeunit/bin/nodeunit test"


### PR DESCRIPTION
Hello @dpup, @koop, @kocodude, @nicks, 

Please review the following commits I made in branch 'jamie-reconnect-support'.

This adds reconnection support for node-bloomd. To test this, I've added
some tests which involve starting and stopping the server. These tests
are non-deterministic, in that if the bloomd takes more than a second to
start up or shut down, subsequent tests will fail. In the future, I/we
might fake bloomd entirely, but this should do for now.

@dpup, code reorg/travis ci is still to come; the build script will be a
little involved.

b599d5e9481ce787b402c7282b4faf61f12fe017 (2013-08-03 20:48:11 -0700)
Add reconnect support

R=@dpup
R=@koop
R=@kocodude
R=@nicks
