### PR TITLE
Create commands to existing filters should not be marked as failed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,14 +161,14 @@ BloomClient.prototype.create = function (filterName, options, callback) {
   for (var key in options) {
     args.push(key + '=' + options[key])
   }
-  this._process('create', filterName, args, responseTypes.CONFIRMATION, function (error, data) {
+  this._process('create', filterName, args, responseTypes.CREATE_CONFIRMATION, function (error, data) {
 
     // First, run the callback.
     if (callback) {
       callback.call(callback, error, data)
     }
 
-	// Then, clear the filter queue if we have one.
+	  // Then, clear the filter queue if we have one.
     self._clearFilterQueue(filterName)
   })
 }
@@ -396,6 +396,10 @@ BloomClient.prototype._onReadable = function () {
 
         case responseTypes.CONFIRMATION:
           data = ResponseParser.parseConfirmation(response)
+          break
+
+        case responseTypes.CREATE_CONFIRMATION:
+          data = ResponseParser.parseCreateConfirmation(response)
           break
 
        case responseTypes.DROP_CONFIRMATION:

--- a/lib/responseParser.js
+++ b/lib/responseParser.js
@@ -45,6 +45,7 @@ ResponseParser.responseTypes = {
   BOOL: 'bool',
   BOOL_LIST: 'boolList',
   CONFIRMATION: 'confirmation',
+  CREATE_CONFIRMATION: 'createConfirmation',
   DROP_CONFIRMATION: 'dropConfirmation',
   FILTER_LIST: 'filterList',
   INFO: 'info'
@@ -153,6 +154,22 @@ ResponseParser.parseBoolList = function (data, keys) {
  */
 ResponseParser.parseConfirmation = function (data) {
   if ('Done' === data) {
+    return true
+  } else {
+    throw new Error(data)
+  }
+}
+
+/**
+ * Parses a Done response from bloomd into a boolean, following a create command.
+ *
+ * For create commands, we don't care if the filter already existed.
+ *
+ * @param {string} data
+ * @return {bool}
+ */
+ResponseParser.parseCreateConfirmation = function (data) {
+  if ('Done' === data || 'Exists' === data) {
     return true
   } else {
     throw new Error(data)


### PR DESCRIPTION
Hello @andrew3886, @nicks, @eford1, @dpup, 

Please review the following commits I made in branch 'jamie-safe-create'.

A create to an existing filter would previously count as an error. This
could cause issues for safe commands being issued to the same filter
from multiple clients, due to a race condition.

771bda9bb74f7f0ec0b5260f18349b63cde63cba (2013-08-05 16:00:01 -0700)
Create commands to existing filters should not be marked as failed.

R=@andrew3886
R=@nicks
R=@eford1
R=@dpup
