### PR TITLE
Handle Internal Errors from bloomd, and allow clients to limit the number of acceptable errors

### DIFF
--- a/lib/responseParser.js
+++ b/lib/responseParser.js
@@ -107,6 +107,16 @@ ResponseParser.prototype._transform = function (chunk, encoding, done) {
 // Static Converters
 
 /**
+ * Detects an internal error from bloomd.
+ *
+ * @param {string} data
+ * @return {bool}
+ */
+ResponseParser.isError = function (data) {
+  return 'Internal Error' === data
+}
+
+/**
  * Parses a Yes/No response from bloomd into a boolean.
  *
  * @param {string} data

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bloomd"
   , "description": "NodeJS Driver for BloomD"
-  , "version": "0.2.2"
+  , "version": "0.2.3"
   , "homepage": "https://github.com/obvious/node-bloomd"
   , "authors": [
     "Jamie Talbot <jamie@jamietalbot.com> (https://github.com/majelbstoat)"


### PR DESCRIPTION
Hello @nicks, @dpup, @yeungsteph, @chaos, 

Please review the following commits I made in branch 'jamie-handle-internal-errors'.

4ae95efc0fad0143f4a8b3dad5d9fc7abf980a09 (2014-05-13 22:17:03 -0700)
Handle Internal Errors from bloomd, and allow clients to limit the number of acceptable errors

This adds support to the client for handling bloomd's internal errors errors more sanely. It
also adds maxErrors, so that an application can control how many internal errors are acceptable
before giving up. Finally, it adds command data onto the returned error object, so we have more
information for debugging when anything unexpected happens.

Next up, I'll be adding a mock bloomd service so we can test failure cases more effectively.

R=@nicks
R=@dpup
R=@yeungsteph
R=@chaosgame
