### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+language: node_js
+node_js:
+- '0.10'
+- '4.2'
+- 'node'
+env:
+- CXX=g++-4.8
+before_install:
+- git clone https://armon@github.com/armon/bloomd.git /tmp/bloomd
+- pushd /tmp/bloomd
+- pip install SCons
+- scons
+- sudo cp ./bloomd /usr/local/bin/
+- popd

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/Medium/node-bloomd.svg?branch=master)](https://travis-ci.org/Medium/node-bloomd)
 node-bloomd
 ===========
 


### PR DESCRIPTION
This configuration will test this module with 0.10 (LTS still supported), 4.2 (Latest LTS) and `node` which is a pointer to latest node. Currently 5.7.

Justification:
Good to know if my dependencies have tests and the are passing.
