### PR TITLE
set this.connected to be true on connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -460,6 +460,7 @@ BloomClient.prototype._onConnect = function () {
     self._onReadable()
   })
 
+  this.connected = true
   this.emit('connected')
   this._drain()
 }


### PR DESCRIPTION
There is a "this.connected" only be set to false on error but never set to true on connect, this pull request only changed one line about this.